### PR TITLE
KOReader vocab importer: truncate long language codes

### DIFF
--- a/vocabsieve/importer/KoreaderVocabImporter.py
+++ b/vocabsieve/importer/KoreaderVocabImporter.py
@@ -21,6 +21,8 @@ def getBookMetadata(path):
         data = slpp.decode(" ".join("\n".join(f.readlines()[1:]).split(" ")[1:]))
         booklang = data['doc_props']['language']
         booktitle = data['doc_props']['title']
+        # truncate long language settings e.g. "tr-TR" -> "tr"
+        booklang = booklang[2:3] == '-' and booklang[:2] or booklang
     return booklang, booktitle
 
 


### PR DESCRIPTION
KOReader vocab importer fails with an unhelpful message if a book is in the correct target language but uses region subtags e.g. `en-US` or `tr-TR`.

This commit simply truncates the language code to the first two letters if there is a third letter in the code and it is "-".

Fixes #70 
