### PR TITLE
feat: add option to capitalize sentence's first letter

### DIFF
--- a/vocabsieve/config.py
+++ b/vocabsieve/config.py
@@ -49,6 +49,10 @@ class SettingsDialog(QDialog):
             "Allow directly editing definition fields")
         self.primary = QCheckBox("Use primary selection")
         self.register_config_handler(self.allow_editing, "allow_editing", True)
+        self.capitalize_first_letter = QCheckBox(
+            "Capitalize first letter of sentence")
+        self.capitalize_first_letter.setToolTip(
+            "Capitalize the first letter of clipboard's content before pasting into the sentence field. Does not affect dictionary lookups.")
         self.lemmatization = QCheckBox(
             "Use lemmatization for dictionary lookups")
         self.lemmatization.setToolTip(
@@ -473,6 +477,7 @@ class SettingsDialog(QDialog):
                     self.text_scale.value() / 100,
                     "1.2f") + "x"))
 
+        self.tab_m.layout.addRow(self.capitalize_first_letter)
         self.tab_m.layout.addRow(QLabel("<h3>Images</h3>"))
         self.tab_m.layout.addRow(QLabel("Image format"), self.img_format)
         self.tab_m.layout.addRow(QLabel("<i>◊ WebP, JPG, GIF are lossy, which create smaller files.</i>"))
@@ -671,6 +676,7 @@ class SettingsDialog(QDialog):
             self.orientation, 'orientation', 'Vertical')
         self.register_config_handler(self.text_scale, 'text_scale', '100')
 
+        self.register_config_handler(self.capitalize_first_letter, 'capitalize_first_letter', False)
         self.register_config_handler(self.img_format, 'img_format', 'jpg')
         self.register_config_handler(self.img_quality, 'img_quality', -1)
 

--- a/vocabsieve/dictionary.py
+++ b/vocabsieve/dictionary.py
@@ -43,16 +43,18 @@ pronunciation_sources = ["Forvo (all)", "Forvo (best)"]
 
 
 
-def preprocess_clipboard(s: str, lang: str) -> str:
+def preprocess_clipboard(s: str, lang: str, should_convert_to_uppercase: bool = False) -> str:
     """
     Pre-process string from clipboard before showing it
     NOTE: originally intended for parsing JA and ZH, but
     that feature has been removed for the time being due
     to maintainence and dependency concerns.
     """
-    return s
-
-
+    # Convert the first letter to uppercase if should_convert_to_uppercase is True
+    if should_convert_to_uppercase:
+        return s[0].upper() + s[1:]
+    else:
+        return s
 
 
 def fmt_result(definitions):

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -805,6 +805,9 @@ class DictionaryWindow(QMainWindow):
         )
         self.image_viewer.setPixmap(content)
 
+    def getConvertToUppercase(self) -> bool:
+        return self.settings.value("convert_uppercase", False, type=bool)
+
     def clipboardChanged(self, evenWhenFocused=False, selection=False):
         """
         If the input is just a single word, we look it up right away.
@@ -825,6 +828,7 @@ class DictionaryWindow(QMainWindow):
             
             text = QApplication.clipboard().text()
 
+        should_convert_to_uppercase = self.getConvertToUppercase()
         lang = self.settings.value("target_language", "en")
         if self.isActiveWindow() and not evenWhenFocused:
             return
@@ -833,16 +837,16 @@ class DictionaryWindow(QMainWindow):
             target = copyobj['word']
             target = re.sub('[\\?\\.!«»…()\\[\\]]*', "", target)
             self.previousWord = target
-            sentence = preprocess_clipboard(copyobj['sentence'], lang)
+            sentence = preprocess_clipboard(copyobj['sentence'], lang, should_convert_to_uppercase)
             self.setSentence(sentence)
             self.setWord(target)
             self.lookupSet(target)
-        elif self.single_word.isChecked() and is_oneword(preprocess_clipboard(text, lang)):
-            self.setSentence(word := preprocess_clipboard(text, lang))
+        elif self.single_word.isChecked() and is_oneword(preprocess_clipboard(text, lang, should_convert_to_uppercase)):
+            self.setSentence(word := preprocess_clipboard(text, lang, should_convert_to_uppercase))
             self.setWord(word)
             self.lookupSet(text)
         else:
-            self.setSentence(preprocess_clipboard(text, lang))
+            self.setSentence(preprocess_clipboard(text, lang, should_convert_to_uppercase))
 
     def lookupSet(self, word, use_lemmatize=True) -> None:
         sentence_text = self.sentence.unboldedText


### PR DESCRIPTION
This PR introduces an option (under misc) that capitalizes the first letter of a sentence.
This is especially useful for subtitles that capture the continuation of a sentence. In such cases, the subtitle might start with a lowercase letter, but it would be more appropriate for the sentence to be capitalized on the Anki card.