### PR TITLE
Fix bug when KoreaderVocabImporter would crash

### DIFF
--- a/vocabsieve/importer/GenericImporter.py
+++ b/vocabsieve/importer/GenericImporter.py
@@ -93,7 +93,7 @@ class GenericImporter(QDialog):
         dates should be strings to the second, such as "1970-01-01 00:00:00".
         Using T in place of the space is NOT allowed.
         """
-        return ((), (), (), ())
+        raise NotImplementedError("Should be implemented by subclasses")
 
     def updateHighlightCount(self):
         start_date = self.datewidget.currentText()

--- a/vocabsieve/importer/KoreaderVocabImporter.py
+++ b/vocabsieve/importer/KoreaderVocabImporter.py
@@ -91,5 +91,7 @@ class KoreaderVocabImporter(GenericImporter):
         except Exception as e:
             print(e)
             self.layout.addRow(QLabel("Failed to find/read lookup_history.lua. Lookups will not be tracked this time."))
-
-        return zip(*items)
+        if items == []:
+            return ([], [], [], [])
+        else:
+            return zip(*items)


### PR DESCRIPTION
If there were no notes to be found, it would return zip(*[]), which could not be unpaced into a four-tuple, causing an exception.
Here, I simply replace it with a hardcoded ([], [], [], []), so it shows an empty list of books instead.

To reproduce the issue, just change your language to something you don't have any books in.
