### PR TITLE
Koreader: Add support for PDF in vocabbuilder

### DIFF
--- a/vocabsieve/importer/GenericImporter.py
+++ b/vocabsieve/importer/GenericImporter.py
@@ -11,13 +11,12 @@ from .utils import truncate_middle
 
 import re
 import json
-
-from vocabsieve.tools import addNotes
 from datetime import datetime as dt
 from .BatchNotePreviewer import BatchNotePreviewer
 from .models import ReadingNote
 from ..models import SRSNote
-from ..tools import prepareAnkiNoteDict
+from ..tools import prepareAnkiNoteDict, addNotes
+from ..global_names import logger
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -120,12 +119,14 @@ class GenericImporter(QDialog):
         """
         raise NotImplementedError("Should be implemented by subclasses")
 
-    def updateHighlightCount(self, filter: bool = True):
+    def updateHighlightCount(self, _=False, filter: bool = True):
         if filter:
+            logger.debug("Filtering highlights by book")
             start_date = self.datewidget.currentText()
             selected_book_names = []
             for checkbox in self.src_checkboxes:
                 if checkbox.isChecked():
+                    logger.debug(f"Selected book: {checkbox.text()}")
                     selected_book_names.append(checkbox.text())
             self.selected_reading_notes = self.filterHighlights(start_date, selected_book_names)
         else:

--- a/vocabsieve/importer/GenericImporter.py
+++ b/vocabsieve/importer/GenericImporter.py
@@ -153,6 +153,7 @@ class GenericImporter(QDialog):
 
 
     def defineWords(self) -> None:
+        logger.info(f"Define words triggered on {len(self.selected_reading_notes)} notes")
         self.anki_notes: list[SRSNote] = []
         self.book_names: list[str] = []
         self.lastDate = "1970-01-01 00:00:00"
@@ -167,6 +168,7 @@ class GenericImporter(QDialog):
         count = 0
         for n_looked_up, note in enumerate(self.selected_reading_notes):
             QCoreApplication.processEvents()
+            logger.debug(f"Handling reading note: {note}")
             self.lastDate = max(note.date, self.lastDate)
             # Remove punctuations
             word = re.sub('[\\?\\.!«»…,()\\[\\]]*', "", note.lookup_term)
@@ -204,28 +206,28 @@ class GenericImporter(QDialog):
                     # First item
                     audio_path = audios[next(iter(audios))]
 
-                tags = []
-                if self.settings.value("tags", "vocabsieve").strip():
-                    tags.extend(self.settings.value("tags", "vocabsieve").strip().split())
-                tags.append(self.methodname)
-                tags.append(note.book_name.replace(" ","_"))
+            tags = []
+            if self.settings.value("tags", "vocabsieve").strip():
+                tags.extend(self.settings.value("tags", "vocabsieve").strip().split())
+            tags.append(self.methodname)
+            tags.append(note.book_name.replace(" ","_"))
 
-                # replace word with headword if it exists
-                if definition1 is not None:
-                    word = definition1.headword
-                elif definition2 is not None:
-                    word = definition2.headword
+            # replace word with headword if it exists
+            if definition1 is not None:
+                word = definition1.headword
+            elif definition2 is not None:
+                word = definition2.headword
 
-                new_note_item = SRSNote(
-                        word=word, # fine if no definition
-                        sentence=sentence, # fine if empty string
-                        definition1=self._parent.definition.process_defi_anki(definition1) if definition1 is not None else None,
-                        definition2=self._parent.definition2.process_defi_anki(definition2) if definition2 is not None else None,
-                        audio_path=audio_path,
-                        tags=tags
-                        )
-                self.preview_widget.appendNoteItem(new_note_item)
-                self.anki_notes.append(new_note_item)
+            new_note_item = SRSNote(
+                    word=word, # fine if no definition
+                    sentence=sentence, # fine if empty string
+                    definition1=self._parent.definition.process_defi_anki(definition1) if definition1 is not None else None,
+                    definition2=self._parent.definition2.process_defi_anki(definition2) if definition2 is not None else None,
+                    audio_path=audio_path or None,
+                    tags=tags
+                    )
+            self.preview_widget.appendNoteItem(new_note_item)
+            self.anki_notes.append(new_note_item)
             self.progressbar.setValue(n_looked_up+1)
         self.progressbar.setValue(len(self.selected_reading_notes))
         

--- a/vocabsieve/importer/KindleVocabImporter.py
+++ b/vocabsieve/importer/KindleVocabImporter.py
@@ -57,7 +57,9 @@ class KindleVocabImporter(GenericImporter):
         lookups_count_before = self._parent.rec.countLookups(langcode)
         for _, lword, bookid, _, _, sentence, timestamp in cur.execute("SELECT * FROM lookups"):
             if lword.startswith(langcode):
-                word = lword.removeprefix(langcode+":")
+                #word = lword.removeprefix(langcode+":")
+                # Remove language code , which may have a suffix for region
+                word = ":".join(lword.split(":")[1:]) # maybe some languages use colons, I don't know
                 count += 1
                 self._parent.rec.recordLookup(
                     LookupRecord(

--- a/vocabsieve/importer/KoreaderVocabImporter.py
+++ b/vocabsieve/importer/KoreaderVocabImporter.py
@@ -73,7 +73,7 @@ class KoreaderVocabImporter(GenericImporter):
             #print(word, title_id)
             if title_id in bookmap:
                 if prev_context and next_context:
-                    ctx = prev_context + word + next_context
+                    ctx = prev_context.strip() + f" {word} " + next_context.strip() # ensure space before and after
                 else:
                     continue
                 sentence = ""

--- a/vocabsieve/importer/utils.py
+++ b/vocabsieve/importer/utils.py
@@ -1,8 +1,8 @@
 from datetime import datetime as dt
 import glob
 import os
-from itertools import zip_longest
-from ..models import Definition, SRSNote
+from ..global_names import logger
+
 
 def get_uniques(l: list):
     return list(set(l) - set([""]))
@@ -30,24 +30,14 @@ def findDBpath(path):
 
 def koreader_scandir(path):
     filelist = []
-    epubs = glob.glob(os.path.join(path, "**/*.epub"), recursive=True)
-    for filename in epubs:
-        if os.path.exists(os.path.join(os.path.dirname(filename), 
-                            filename.removesuffix("epub") + "sdr", 
-                            "metadata.epub.lua")):
-            filelist.append(filename)
-    fb2s = glob.glob(os.path.join(path, "**/*.fb2"), recursive=True)
-    for filename in fb2s:
-        if os.path.exists(os.path.join(os.path.dirname(filename), 
-                          filename.removesuffix("fb2") + "sdr", 
-                          "metadata.fb2.lua")):
-            filelist.append(filename)
-    fb2zips = glob.glob(os.path.join(path, "**/*.fb2.zip"), recursive=True)
-    for filename in fb2zips:
-        if os.path.exists(os.path.join(os.path.dirname(filename), 
-                          filename.removesuffix("zip") + "sdr", 
-                          "metadata.zip.lua")):
-            filelist.append(filename)
+    for filetype in ["epub", "fb2", "fb2.zip", "pdf"]:
+        files = glob.glob(os.path.join(path, "**/*." + filetype), recursive=True)
+        for filename in files:
+            if os.path.exists(os.path.join(os.path.dirname(filename),
+                filename.removesuffix(filetype) + "sdr",
+                "metadata." + filetype.split(".")[-1] + ".lua")):
+                filelist.append(filename)
+    logger.info(f"Found {len(filelist)} book files in {path}: {filelist}")
     return filelist
 
 def findHistoryPath(path):


### PR DESCRIPTION
I found myself reading a PDF file recently, and I noticed VocabSieve wasn't importing the vocabulary from it. This PR fixes that, adding PDF to the list of supported filetypes.

EDIT: I see that this closes #75. I hadn't looked at that issue before opening this PR. For the concrete book I wanted to import data from, I did get the issue with a lack of spaces around the highlighted word. Additionally, I sort of had to ninja-edit the language field of the metadata in koreader while importing with vocabsieve. 