### PR TITLE
Bugfix: Return results from the 2nd dictionary even if 1st fails

### DIFF
--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -988,7 +988,6 @@ class DictionaryWindow(QMainWindow):
                 "word": word,
                 "definition": failed_lookup(word, self.settings)
             }
-            return item
         dict2name = self.settings.value("dict_source2", "<disabled>")
         if dict2name == "<disabled>":
             return item


### PR DESCRIPTION
Fixes a bug where 2nd dictionary would be ignored if the 1st one fails. Found it myself, not sure if it was actually reported. To reproduce, enable 2 dictionaries and search for a word that exists in the 2nd dict but not the first one (don't have an example, sorry, as I was using a local dict for testing)