### PR TITLE
Add file extensions to fetched audio

### DIFF
--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -871,7 +871,8 @@ class DictionaryWindow(QMainWindow):
         self.audio_selector.clear()
         if len(self.audios):
             for item in self.audios:
-                self.audio_selector.addItem("🔊 " + item)
+                file_extension = self.audios[item].split(".")[-1]
+                self.audio_selector.addItem("🔊 " + item + "." + file_extension)
             self.audio_selector.setCurrentItem(self.audio_selector.item(0))
 
     def fetchAudioInBackground(self, word):


### PR DESCRIPTION
Motivation to create the PR is that .ogg files aren't playable on iOS Anki so given the choice between 2 equivalent files, 1 mp3 and 1 - .ogg, I'd pick the first one. 

![image](https://github.com/FreeLanguageTools/vocabsieve/assets/6875790/e5c79268-c592-460a-bd53-2c0fe52d1d00)
