### PR TITLE
Fix audio not previewing

### DIFF
--- a/vocabsieve/dictionary.py
+++ b/vocabsieve/dictionary.py
@@ -122,13 +122,13 @@ def getCognatesData(language: str, known_langs: list) -> Optional[List[str]]:
     print("Got all cognates in", time.time() - start, "seconds")
     return cognates
 
-def getAudio(word: str, 
-             language: str, 
-             dictionary: str="Forvo (all)", 
+def getAudio(word: str,
+             language: str,
+             dictionary: str="Forvo (all)",
              custom_dicts:Optional[list]=None) -> Dict[str, str]:
     if custom_dicts is None:
         custom_dicts = []
-    
+
     # should return a dict of audio names and paths to audio
     if dictionary == "Forvo (all)":
         return fetch_audio_all(word, language)
@@ -278,18 +278,18 @@ def play_audio(name: str, data: Dict[str, str], lang: str) -> str:
         crossplatform_playsound(audiopath)
         return audiopath
 
-    fpath = os.path.join(forvopath, lang, name) + audiopath[-4:]
+    fpath = os.path.join(forvopath, lang, name)
     if not os.path.exists(fpath):
         res = requests.get(audiopath, headers=HEADERS)
 
         if res.status_code != 200:
             # /TODO: Maybe display error to the user?
             return ""
-        
+
         os.makedirs(os.path.dirname(fpath), exist_ok=True)
         with open(fpath, 'bw') as file:
             file.write(res.content)
-    
+
     crossplatform_playsound(fpath)
     return fpath
 

--- a/vocabsieve/forvo.py
+++ b/vocabsieve/forvo.py
@@ -144,7 +144,8 @@ def fetch_audio_all(word: str, lang: str) -> Dict[str, str]:
     if len(sounds) == 0:
         return result
     for item in sounds:
-        result[item.origin + "/" + item.headword] = item.download_url
+        file_extension = item.download_url.split(".")[-1]
+        result[item.origin + "/" + item.headword + "." + file_extension] = item.download_url
     return result
 
 

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -871,8 +871,7 @@ class DictionaryWindow(QMainWindow):
         self.audio_selector.clear()
         if len(self.audios):
             for item in self.audios:
-                file_extension = self.audios[item].split(".")[-1]
-                self.audio_selector.addItem("🔊 " + item + "." + file_extension)
+                self.audio_selector.addItem("🔊 " + item)
             self.audio_selector.setCurrentItem(self.audio_selector.item(0))
 
     def fetchAudioInBackground(self, word):


### PR DESCRIPTION
Introduced in https://github.com/FreeLanguageTools/vocabsieve/pull/99 (sorry about that, not sure how I missed that!), audio wasn't playing at all in the preview. This is because the entries would get added to `audio_selector` with a file extension but they still would be expected to be without a file extension when grabbing a pronunciation (dictionary.py:273)

Extraction of the file extension is now deeper down at the forvo level. I've also reverted my previous changes in `updateAudioUI` and removed the now unneeded file extension concatenation in `dictionary.py:281` (to prevent e.g. `file.mp3.mp3`)