### PR TITLE
Fix pronunciation and definition being out of sync with searched word

### DIFF
--- a/vocabsieve/dictionary.py
+++ b/vocabsieve/dictionary.py
@@ -141,7 +141,6 @@ def getAudio(word: str,
                     data = lookupin(
                         word.lower(),
                         language,
-                        lemmatize=False,
                         dictionary=d['name'])
                     if data['definition']:
                         data['definition'] = json.loads(data['definition'])
@@ -159,7 +158,6 @@ def getAudio(word: str,
     data = lookupin(
         word.lower(),
         language,
-        lemmatize=False,
         dictionary=dictionary)
     data['definition'] = json.loads(data['definition'])
     for d in custom_dicts:
@@ -176,7 +174,6 @@ def getAudio(word: str,
 def lookupin(
         word: str,
         language: str,
-        lemmatize: bool=True,
         greedy_lemmatize: bool=False,
         dictionary: str="Wiktionary (English)",
         gtrans_lang: str="en",
@@ -186,8 +183,6 @@ def lookupin(
     if not word:
         return word
     IS_UPPER = word[0].isupper()
-    if lemmatize and not " " in word:
-        word = lem_word(word, language, greedy_lemmatize)
     # The lemmatizer would always turn words lowercase, which can cause
     # lookups to fail if not recovered.
     candidates = [word.lower(), word.capitalize()] if IS_UPPER else [word]

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -938,7 +938,7 @@ class DictionaryWindow(QMainWindow):
         self.audio_path = ""
 
         if self.settings.value("audio_dict", "Forvo (all)") != "<disabled>":
-            threading.Thread(target=self.fetchAudioInBackground, args=(word,)).start()
+            threading.Thread(target=self.fetchAudioInBackground, args=(result['word'],)).start()
 
     def getLanguage(self) -> str:
         return self.settings.value("target_language", "en")  # type: ignore
@@ -960,7 +960,6 @@ class DictionaryWindow(QMainWindow):
         lemfreq = self.settings.value("lemfreq", True, type=bool)
         short_sign = "Y" if lemmatize else "N"
         language = self.getLanguage()
-        TL = language  # Handy synonym
         gtrans_lang: str = self.settings.value("gtrans_lang", "en")
         dictname: str = self.settings.value("dict_source", "Wiktionary (English)")
         freqname: str = self.settings.value("freq_source", "<disabled>")
@@ -985,8 +984,9 @@ class DictionaryWindow(QMainWindow):
                     self.freq_display.setText(freq_to_stars(1e6, lemfreq))
         self.status(
             f"L: '{word}' in '{language}', lemma: {short_sign}, from {dictionaries.get(dictname, dictname)}")
+        if lemmatize and not " " in word:
+            word = lem_word(word, language, lem_greedily)
         if dictname == "<disabled>":
-            word = lem_word(word, language, lem_greedily) if lemmatize else word
             self.status("Dict disabled")
             return {
                 "word": word,
@@ -996,7 +996,6 @@ class DictionaryWindow(QMainWindow):
             item = lookupin(
                 word,
                 language,
-                lemmatize,
                 lem_greedily,
                 dictname,
                 gtrans_lang,
@@ -1014,7 +1013,6 @@ class DictionaryWindow(QMainWindow):
             item2: LookUpResults = lookupin(
                 word,
                 language,
-                lemmatize,
                 lem_greedily,
                 dict2name,
                 gtrans_lang)


### PR DESCRIPTION
There are currently a few edge cases where a part of the app uses either lemmatized or non-lemmatized version. This PR aims to fix that and put all the fields in sync. Basically, lemmatize as early as possible (if desired) so the same version of the word is used.

Couple of bugs that I found:
(For all examples, set language to Portuguese and use Wiktionary as source) 
- Define `raposa` - no matches found. But if you do a Direct Define of `raposa` - VS will correctly find the definition. In both cases, Word field is populated with `raposa`, making it seem like the first definition couldn't be found. What actually happened is that `raposa` was lemma'd into `raposar`, which wasn't found
- Define `nos`. VS would lemma `nos` into `o`  and define `o`. But pronunciations would still be retrieved for `nos`.