### PR TITLE
Shortcut improvements

### DIFF
--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -579,6 +579,8 @@ class MainWindow(MainWindowBase):
     def setupShortcuts(self) -> None:
         self.shortcut_toanki = QShortcut(QKeySequence('Ctrl+S'), self)
         self.shortcut_toanki.activated.connect(self.toanki_button.animateClick)
+        self.shortcut_double_click_toggle = QShortcut(QKeySequence('Ctrl+2'), self)
+        self.shortcut_double_click_toggle.activated.connect(self.lookup_definition_on_doubleclick.animateClick)
         self.shortcut_view_note = QShortcut(QKeySequence('Ctrl+F'), self)
         self.shortcut_view_last_note = QShortcut(QKeySequence('Ctrl+Shift+F'), self)
         self.shortcut_view_last_note.activated.connect(self.view_last_note_button.animateClick)

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -594,7 +594,7 @@ class MainWindow(MainWindowBase):
         self.shortcut_web.activated.connect(self.web_button.animateClick)
         self.shortcut_clearimage = QShortcut(QKeySequence('Ctrl+W'), self)
         self.shortcut_clearimage.activated.connect(lambda: self.setImage(None))
-        self.shortcut_clearaudio = QShortcut(QKeySequence('Ctrl+X'), self)
+        self.shortcut_clearaudio = QShortcut(QKeySequence('Ctrl+Shift+X'), self)
         self.shortcut_clearaudio.activated.connect(self.audio_selector.discard_audio_button.animateClick)
 
     def getCurrentWord(self) -> str:

--- a/vocabsieve/ui/audio_selector.py
+++ b/vocabsieve/ui/audio_selector.py
@@ -22,7 +22,7 @@ class AudioSelector(QListWidget):
 
         
         self.discard_audio_button.clicked.connect(self.clear)
-        self.discard_audio_button.setToolTip(f"Discard audio [{MOD}+X]")
+        self.discard_audio_button.setToolTip(f"Discard audio [{MOD}+Shift+X]")
         
         icon = self.style().standardIcon(QStyle.SP_TrashIcon)
         self.discard_audio_button.setIcon(icon)

--- a/vocabsieve/ui/main_window_base.py
+++ b/vocabsieve/ui/main_window_base.py
@@ -103,7 +103,7 @@ class MainWindowBase(QMainWindow):
             ", then press \"Get definition\".")
 
         self.lookup_button = QPushButton(f"Define [{MOD}+D]") 
-        self.lookup_exact_button = QPushButton(f"Define direct [Shift-{MOD}+D]")
+        self.lookup_exact_button = QPushButton(f"Define direct [Shift+{MOD}+D]")
         self.lookup_exact_button.setToolTip(
             "This will look up the word without lemmatization.")
         self.toanki_button = QPushButton(f"Add note [{MOD}+S]")
@@ -126,7 +126,7 @@ class MainWindowBase(QMainWindow):
         self.lookup_definition_on_doubleclick = QCheckBox(
             "Lookup definition on double click")
         self.lookup_definition_on_doubleclick.setToolTip(
-            "Disable this if you want to use 3rd party dictionaries with copied text (e.g. with mpvacious).")
+            f"Disable this if you want to use 3rd party dictionaries with copied text (e.g. with mpvacious).[{MOD}+2]")
         self.lookup_definition_on_doubleclick.clicked.connect(lambda v: self.settings.setValue("lookup_definition_on_doubleclick", v))
         self.lookup_definition_on_doubleclick.setChecked(self.settings.value("lookup_definition_on_doubleclick", True, type=bool))
         self.lookup_definition_when_hovering = QCheckBox("Lookup definition when hovering")


### PR DESCRIPTION
- Shortcut for Double click toggle
- I've changed Discard Audio shortcut from `Ctrl+X` to `Ctrl+Shift+X` because `Ctrl+X` was being overriden by `Cut` functionality when a field was in focus, at least on Windows. So the shortcut wouldn't always work