### PR TITLE
Word field improvements

### DIFF
--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -580,9 +580,11 @@ class MainWindow(MainWindowBase):
         selected2 = cursor2.selectedText()
         cursor3 = self.definition2.textCursor()
         selected3 = cursor3.selectedText()
+        selected4 = self.word.selectedText()
         target = str.strip(selected
                            or selected2
                            or selected3
+                           or selected4
                            or self.previousWord
                            or self.word.text()
                            or "")

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -628,9 +628,11 @@ class MainWindow(MainWindowBase):
                     WordRecord(lemma=lemma, language=langcode)
                     )
                 self.word_record_display.setWordRecord(word_record, self.getWordActionWeights())
-            self.definition.lookup(target, no_lemma)
-            if self.settings.value("sg2_enabled", False, type=bool):
-                self.definition2.lookup(target, no_lemma)
+            lookup1_result_success = self.definition.lookup(target, no_lemma)
+            lookup2_result_success = self.settings.value("sg2_enabled", False, type=bool) and self.definition2.lookup(target, no_lemma)
+            if not (lookup1_result_success or lookup2_result_success):
+                self.word.setText(target)
+
             self.audio_selector.lookup(target)
             self.freq_widget.lookup(target)
         


### PR DESCRIPTION
Partially fixes https://github.com/FreeLanguageTools/vocabsieve/issues/107 by setting the contents of Word field with whatever was searched if both dict groups return nothing. 

There's still a scenario where target is not found in the 1st group but found in the 2nd. Currently, the Word field mirrors whatever is defined in the 1st group. To get around this, I was thinking the following: always pass `word_widget` to `MultiDefinitionWidget`. In addition, pass `lookup1_result_success` to `MultiDefinitionWidget.setCurrentDefinition()`. If  `lookup1_result_success == False`, then set the Word field with the contents of the result of the 2nd group, assuming that something was found. Thoughts?

---

I've also allowed Ctrl+D to work on the Word field, to make it easier to search for words in case it didn't find the correct lemma on the 1st try