### PR TITLE
Select word only if it is in focus

### DIFF
--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -577,17 +577,13 @@ class MainWindow(MainWindowBase):
 
     def getCurrentWord(self) -> str:
         """Returns currently selected word. If there isn't any, last selected word is returned"""
-        cursor = self.sentence.textCursor()
-        selected = cursor.selectedText()
-        cursor2 = self.definition.textCursor()
-        selected2 = cursor2.selectedText()
-        cursor3 = self.definition2.textCursor()
-        selected3 = cursor3.selectedText()
-        selected4 = self.word.selectedText()
-        target = str.strip(selected
-                           or selected2
-                           or selected3
-                           or selected4
+        target = ''
+        for text_field in [self.sentence, self.definition, self.definition2]:
+            if text_field.hasFocus():
+                target = text_field.textCursor().selectedText()
+        if self.word.hasFocus():
+            target = self.word.selectedText()
+        target = str.strip(target
                            or self.previousWord
                            or self.word.text()
                            or "")


### PR DESCRIPTION
Basically check `hasFocus()` before confirming word as `target`. This fixes a bug where if multiple selections will be made within the app, the first selection would be preferred, rather than the currently selected one (which is most likely the one that the user wants)  