### PR TITLE
Fix bug where BookAnalyzer would only work for ru and uk

### DIFF
--- a/vocabsieve/analyzer/BookAnalyzer.py
+++ b/vocabsieve/analyzer/BookAnalyzer.py
@@ -38,6 +38,8 @@ class BookAnalyzer(QDialog):
         self.basic_info_left = ""
         if self.langcode in ['ru', 'uk']:
             self.known_words = set([word for word in self.known_words if starts_with_cyrillic(word)])
+        else:
+            self.known_words = set([word for word in self.known_words])
         
         self.content = "\n".join(self.chapters)
         


### PR DESCRIPTION
In the case the language configured was neither `ru` or `uk`, known_words would be a list and not a set, leading to type errors