### PR TITLE
Introduce a general error handler

### DIFF
--- a/vocabsieve/audio_player.py
+++ b/vocabsieve/audio_player.py
@@ -26,10 +26,7 @@ class AudioPlayer:
       fpath = os.path.join(forvopath, lang, name)
       if not os.path.exists(fpath):
           res = requests.get(audiopath, headers=FORVO_HEADERS)
-
-          if res.status_code != 200:
-              # /TODO: Maybe display error to the user?
-              return ""
+          res.raise_for_status()
 
           os.makedirs(os.path.dirname(fpath), exist_ok=True)
           with open(fpath, 'bw') as file:

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -37,6 +37,7 @@ from .models import (DictionarySourceGroup, KnownMetadata, LookupRecord, SRSNote
                      WordRecord)
 from sentence_splitter import SentenceSplitter
 from .lemmatizer import lem_word
+from .uncaught_hook import ExceptionCatcher
 
 
 class MainWindow(MainWindowBase):
@@ -45,6 +46,7 @@ class MainWindow(MainWindowBase):
     polled_selection_changed = pyqtSignal()
     def __init__(self) -> None:
         super().__init__()
+        self.catcher = ExceptionCatcher()
         self.datapath = datapath
         self.thread_manager = QThreadPool()
         self.known_data: Optional[dict[str, WordRecord]] = None

--- a/vocabsieve/uncaught_hook.py
+++ b/vocabsieve/uncaught_hook.py
@@ -1,6 +1,7 @@
 from PyQt5.QtCore import pyqtSignal, QObject
 from PyQt5.QtWidgets import QMessageBox
 import traceback
+from loguru import logger
 import sys
 
 class ExceptionCatcher(QObject):
@@ -12,7 +13,7 @@ class ExceptionCatcher(QObject):
         self.exception_signal.connect(self.make_error_box)
 
     def make_error_box(self, e_type, e_value, e_trace):
-        traceback.print_exception(e_type, e_value, e_trace)
+        logger.error("".join(traceback.format_exception(e_type, e_value, e_trace)))
         msg = QMessageBox()
         msg.setIcon(QMessageBox.Icon.Critical)
         msg.setText(traceback.format_exception_only(e_type, e_value)[-1])

--- a/vocabsieve/uncaught_hook.py
+++ b/vocabsieve/uncaught_hook.py
@@ -1,0 +1,27 @@
+from PyQt5.QtCore import pyqtSignal, QObject
+from PyQt5.QtWidgets import QMessageBox
+import traceback
+import sys
+
+class ExceptionCatcher(QObject):
+    exception_signal = pyqtSignal(object, object, object)
+
+    def __init__(self):
+        super().__init__()
+        sys.excepthook = self.except_hook
+        self.exception_signal.connect(self.make_error_box)
+
+    def make_error_box(self, e_type, e_value, e_trace):
+        traceback.print_exception(e_type, e_value, e_trace)
+        msg = QMessageBox()
+        msg.setIcon(QMessageBox.Icon.Critical)
+        msg.setText(traceback.format_exception_only(e_type, e_value)[-1])
+        msg.setInformativeText("".join(traceback.format_exception(e_type, e_value, e_trace)[:10]))
+        msg.exec()
+
+    def except_hook(self, e_type, e_value, e_trace):
+        # To avoid CTRL+C causing an error
+        if e_type != KeyboardInterrupt:
+            self.exception_signal.emit(e_type, e_value, e_trace)
+
+


### PR DESCRIPTION
Uncaught exceptions will be caught by this handler, and it will present
a dialog with a stack trace, but also still print the error to the console.

Also, make issues fetching forvo clips throw exceptions, which is a
great way to test it. 

Being able to see when something goes wrong is really a great usability improvement imho
