### PR TITLE
Fix exception in WiktionarySource

### DIFF
--- a/vocabsieve/sources/WiktionarySource.py
+++ b/vocabsieve/sources/WiktionarySource.py
@@ -32,7 +32,10 @@ class WiktionarySource(DictionarySource):
         if res.status_code != 200:
             return LookupResult(error=str(res.text))
         definitions = []
-        data = res.json()[self.langcode]
+        data = res.json()
+        if self.langcode not in data.keys():
+            return LookupResult(error="Word not defined in language")
+        data = data[self.langcode]
         for item in data:
             meanings = []
             for defn in item['definitions']:


### PR DESCRIPTION
The WiktionarySource depended on the status code to check if a word was defined.
If a word was not defined in the target language, but in some other language, the WiktionarySource would throw a KeyError.
This commit adds a simple check to fix that.
