### PR TITLE
Added fallback for hovering lookup on Linux systems

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     packaging
     typing_extensions
     gevent
-    pynput
+    keyboard
 
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     packaging
     typing_extensions
     gevent
-    keyboard
+    pynput
 
 
 [options.entry_points]

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -1029,7 +1029,7 @@ def main():
     w.audio_selector.alignDiscardButton() # fix annoying issue of misalignment
     try:
         app.exec()
-        w.shift_monitor.stop_monitoring()
+        w.monitor.stop_monitoring()
     except KeyboardInterrupt:
         print("Exiting...")
         sys.exit(0)

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -1029,7 +1029,8 @@ def main():
     w.audio_selector.alignDiscardButton() # fix annoying issue of misalignment
     try:
         app.exec()
-        w.monitor.stop_monitoring()
+        if not w.is_linux:
+            w.monitor.stop_monitoring()
     except KeyboardInterrupt:
         print("Exiting...")
         sys.exit(0)

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -1029,7 +1029,7 @@ def main():
     w.audio_selector.alignDiscardButton() # fix annoying issue of misalignment
     try:
         app.exec()
-        w.monitor.stop_monitoring()
+        w.shift_monitor.stop_monitoring()
     except KeyboardInterrupt:
         print("Exiting...")
         sys.exit(0)

--- a/vocabsieve/main.py
+++ b/vocabsieve/main.py
@@ -1029,7 +1029,7 @@ def main():
     w.audio_selector.alignDiscardButton() # fix annoying issue of misalignment
     try:
         app.exec()
-        if not w.is_linux:
+        if not w.is_wayland:
             w.monitor.stop_monitoring()
     except KeyboardInterrupt:
         print("Exiting...")

--- a/vocabsieve/text_manipulation.py
+++ b/vocabsieve/text_manipulation.py
@@ -56,7 +56,6 @@ def bold_word_in_text(
     language,
     use_lemmatize=True, 
     greedy_lemmatize=False):
-    print(text)
     if not use_lemmatize:
         return re.sub(word, lambda match: apply_bold(match.group(0)), text)
     else:

--- a/vocabsieve/ui/main_window_base.py
+++ b/vocabsieve/ui/main_window_base.py
@@ -48,7 +48,7 @@ class MainWindowBase(QMainWindow):
         self.audio_path = ""
         self.prev_clipboard = ""
         self.image_path = ""
-        self.is_linux = platform.system() == "Linux"
+        self.is_wayland = os.environ.get("XDG_SESSION_TYPE") == "wayland"
 
         self.scaleFont()
         self.initWidgets()
@@ -60,7 +60,7 @@ class MainWindowBase(QMainWindow):
         self.setupWidgetsV()
 
         # Setup Key monitoring to monitor the shit key
-        if not self.is_linux:
+        if not self.is_wayland:
             self.monitor = ShiftMonitor()
             self.monitor.keyEvent.connect(self.shiftMonitorEvent)
             self.monitor.start_monitoring()
@@ -78,13 +78,13 @@ class MainWindowBase(QMainWindow):
 
 
     def keyPressEvent(self, event: QKeyEvent | None) -> None:
-        if self.is_linux and event.key() == Qt.Key.Key_Shift:
+        if self.is_wayland and event.key() == Qt.Key.Key_Shift:
             self.shift_pressed = True
         else:
             super().keyPressEvent(event)
     
     def keyReleaseEvent(self, event: QKeyEvent | None) -> None:
-        if self.is_linux and event.key() == Qt.Key.Key_Shift:
+        if self.is_wayland and event.key() == Qt.Key.Key_Shift:
             self.shift_pressed = False
         else:
             super().keyReleaseEvent(event)

--- a/vocabsieve/ui/main_window_base.py
+++ b/vocabsieve/ui/main_window_base.py
@@ -21,8 +21,7 @@ from ..models import AnkiSettings, WordActionWeights, KeyAction
 import platform
 import os
 from sentence_splitter import SentenceSplitter
-from pynput import keyboard
-
+import keyboard
 
 # If on macOS, display the modifier key as "Cmd", else display it as "Ctrl".
 # For whatever reason, Qt automatically uses Cmd key when Ctrl is specified on Mac
@@ -55,9 +54,9 @@ class MainWindowBase(QMainWindow):
         self.setupWidgetsV()
 
         # Setup Key monitoring to monitor the shit key
-        self.monitor = KeyMonitor()
-        self.monitor.keyEvent.connect(self.monitorEvent)
-        self.monitor.start_monitoring()
+        self.shift_monitor = ShiftMonitor()
+        self.shift_monitor.keyEvent.connect(self.monitorEvent)
+        self.shift_monitor.start_monitoring()
         self.shift_pressed: bool = False
 
     def monitorEvent(self, action):
@@ -253,24 +252,24 @@ class MainWindowBase(QMainWindow):
         )
 
 
-class KeyMonitor(QObject):
+class ShiftMonitor(QObject):
     """Monitors the activity of the shift key"""
-    keyEvent = pyqtSignal(KeyAction)
-    
+    keyEvent = pyqtSignal(KeyAction) 
+
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.listener = keyboard.Listener(on_press=self.on_press,on_release=self.on_release)
 
-    def on_press(self, key):
-        if key == keyboard.Key.shift:
-            self.keyEvent.emit(KeyAction.pressed)
-
-    def on_release(self, key):
-        if key == keyboard.Key.shift:
-            self.keyEvent.emit(KeyAction.released)
-
-    def stop_monitoring(self):
-        self.listener.stop()
+    def callback(self, event: keyboard.KeyboardEvent):
+        match event.event_type:
+            case keyboard.KEY_DOWN:
+                self.keyEvent.emit(KeyAction.pressed)
+            case keyboard.KEY_UP:
+                self.keyEvent.emit(KeyAction.released)
+            case _:
+                pass
 
     def start_monitoring(self):
-        self.listener.start()   
+        self.event_handler = keyboard.hook_key('shift', self.callback)
+
+    def stop_monitoring(self):
+        keyboard.unhook_key(self.event_handler)


### PR DESCRIPTION
As per requested, I added the fallback for hovering lookup with the shift key. So it should now work on Linux, though the window must be focused. However, I think that it would be more useful if we let the user decide whether they want the fallback or not, but I didn't add that feature so we can discuss it and see what works best for you. The pynput [documentation](https://pynput.readthedocs.io/en/latest/limitations.html#linux) states that if the script is running under X, it should work regardless of the sudo privileges. This way, if someone it's still using X, they might benefit from using the hovering lookup feature even when the window is unfocused.