### PR TITLE
scroll wheel improvements for definitions

### DIFF
--- a/vocabsieve/ui/multi_definition_widget.py
+++ b/vocabsieve/ui/multi_definition_widget.py
@@ -106,18 +106,21 @@ class MultiDefinitionWidget(SearchableTextEdit):
         self.workers: list[LookupWorker] = []
 
     def wheelEvent(self, event):
-        if self.verticalScrollBar().value() == self.verticalScrollBar().minimum() and event.angleDelta().y() > 0:
-            self.nextDefinitionScrollTransitionCounter += 1
-            if self.nextDefinitionScrollTransitionCounter > NEXT_DEFINITION_SCROLL_COUNT_TRANSITION_THRESHOLD:
-                self.back()
+        if len(self.sources) > 1:
+            if self.verticalScrollBar().value() == self.verticalScrollBar().minimum() and event.angleDelta().y() > 0:
+                self.nextDefinitionScrollTransitionCounter += 1
+                if self.nextDefinitionScrollTransitionCounter > NEXT_DEFINITION_SCROLL_COUNT_TRANSITION_THRESHOLD:
+                    self.back()
+                    return
 
-        elif self.verticalScrollBar().value() == self.verticalScrollBar().maximum() and event.angleDelta().y() < 0:
-            self.nextDefinitionScrollTransitionCounter += 1
-            if self.nextDefinitionScrollTransitionCounter > NEXT_DEFINITION_SCROLL_COUNT_TRANSITION_THRESHOLD:
-                self.forward()
+            elif self.verticalScrollBar().value() == self.verticalScrollBar().maximum() and event.angleDelta().y() < 0:
+                self.nextDefinitionScrollTransitionCounter += 1
+                if self.nextDefinitionScrollTransitionCounter > NEXT_DEFINITION_SCROLL_COUNT_TRANSITION_THRESHOLD:
+                    self.forward()
+                    return
 
-        else:
-            self.nextDefinitionScrollTransitionCounter = 0
+            else:
+                self.nextDefinitionScrollTransitionCounter = 0
 
         super().wheelEvent(event)
 


### PR DESCRIPTION
I've added 2 small QoLs for using the scroll wheel to change definitions:

- `if len(self.sources) > 1:` to disable changing definition on scroll wheel where there is only 1 definition (currently it will wrap)
- `return` statements after self.forward/back so that the wheel event wouldn't trigger an additional time - this would cause the next/previous definition to scroll a bit immediately after switching 