### PR TITLE
Fix DSL parsing for files using spaces

### DIFF
--- a/vocabsieve/dictformats.py
+++ b/vocabsieve/dictformats.py
@@ -189,17 +189,17 @@ def parseDSL(path) -> dict[str, str]:
     data = {}
     items = []
     for item in allLines.splitlines():
-        if not item.startswith("#") and not item.startswith("\t"):
+        if not item.startswith("#") and not item.startswith("\t") and not item.startswith(" "):
             data[current_term] = re.sub(r'(\d+\.)<br>\s*(\D+)', r'\1 \2', current_defi)\
                                    .removesuffix("<br>").strip()
 
             current_defi = ""
             current_term = item
-        if item.startswith("\t"):
+        if item.startswith("\t") or item.startswith(" "):
             items.append(item)
             if item.endswith(".wav"):  # Don't include audio file names
                 continue
-            current_defi += item.removeprefix("\t").replace("~", current_term) + "<br>"
+            current_defi += item.lstrip().replace("~", current_term) + "<br>"
 
     return data
 


### PR DESCRIPTION
This PR resolves issue #183 

The DSL dictionary file format allows for leading spaces or tabs to delineate the card word body for each headword, but the current implementation only accounts for TAB characters.

See https://documentation.help/ABBYY-Lingvo8/EntryStructure.htm for details on the DSL format.


It's a pretty simple fix. Now the DSL parsing function checks for leading spaces, not just TAB characters when parsing the card blocks. Please let me know if I need to add anything else or write any tests etc.