### PR TITLE
Tab improvements

### DIFF
--- a/vocabsieve/ui/multi_definition_widget.py
+++ b/vocabsieve/ui/multi_definition_widget.py
@@ -92,9 +92,11 @@ class MultiDefinitionWidget(SearchableTextEdit):
         buttons_box_widget.scrolled.connect(self.move_)
 
         prev_button = QPushButton("<")
+        prev_button.setFocusPolicy(Qt.NoFocus)
         self.counter = QLabel("0/0")
         self.counter.setAlignment(Qt.AlignCenter)
         next_button = QPushButton(">")
+        next_button.setFocusPolicy(Qt.NoFocus)
         buttons_box_layout.addWidget(prev_button)
         buttons_box_layout.addWidget(next_button)
         buttons_box_layout.addWidget(self.counter)

--- a/vocabsieve/ui/searchable_text_edit.py
+++ b/vocabsieve/ui/searchable_text_edit.py
@@ -10,6 +10,7 @@ class SearchableTextEdit(QTextEdit):
 
     def __init__(self):
         super().__init__()
+        self.setTabChangesFocus(True);
         self.setMouseTracking(True)
         self.word_under_cursor = ""
         self.prev_emitted_word = ""


### PR DESCRIPTION
- Removed arrows from Tab navigation as there's no UI to highlight them and a bit clunky anyway (as it takes 3 Tab presses to get from Definition 1 to Definition 2) 
- Allow Tab navigation from all multiline fields - much more useful than inserting whitespace