### PR TITLE
Preserve original sentence in KOReader imports

### DIFF
--- a/vocabsieve/importer/GenericImporter.py
+++ b/vocabsieve/importer/GenericImporter.py
@@ -173,6 +173,10 @@ class GenericImporter(QDialog):
             word = remove_punctuations(note.lookup_term)
             if settings.value("bold_word", True, type=bool):
                 sentence = note.sentence.replace(word, f"<strong>{word}</strong>")
+
+                if note.highlight and (note.highlight != note.lookup_term):
+                    highlight = remove_punctuations(note.highlight)
+                    sentence = note.sentence.replace(highlight, f"<strong>{highlight}</strong>")
             else:
                 sentence = note.sentence
 

--- a/vocabsieve/importer/KoreaderVocabImporter.py
+++ b/vocabsieve/importer/KoreaderVocabImporter.py
@@ -63,16 +63,22 @@ class KoreaderVocabImporter(GenericImporter):
                 bookmap[bookid] = bookname
 
         reading_notes = []
-        for timestamp, word, title_id, prev_context, next_context in cur.execute(
-                "SELECT create_time, word, title_id, prev_context, next_context FROM vocabulary"):
+        for timestamp, word, title_id, prev_context, next_context, highlight in cur.execute(
+                "SELECT create_time, word, title_id, prev_context, next_context, highlight FROM vocabulary"):
             if title_id in bookmap:
+                # highlight is only populated if the word differs from the
+                # lookup term, e.g. if the language changes noun endings based
+                # on case.
+                if not highlight:
+                    highlight = word
+
                 if prev_context and next_context:
-                    ctx = prev_context.strip() + f" {word} " + next_context.strip()  # ensure space before and after
+                    ctx = prev_context.strip() + f" {highlight} " + next_context.strip()  # ensure space before and after
                 else:
                     continue
                 sentence = ""
                 for sentence_ in self.splitter.split(ctx):
-                    if word in sentence_:
+                    if highlight in sentence_:
                         sentence = sentence_
                 if sentence:
                     count += 1
@@ -80,6 +86,7 @@ class KoreaderVocabImporter(GenericImporter):
                     reading_notes.append(
                         ReadingNote(
                             lookup_term=word,
+                            highlight=highlight,
                             sentence=sentence,
                             book_name=bookmap[title_id],
                             date=str(dt.fromtimestamp(timestamp).astimezone())[:19]

--- a/vocabsieve/importer/models.py
+++ b/vocabsieve/importer/models.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 class ReadingNote:
     """Represents a highlight/note/whatever in an ereader vocab builder"""
     lookup_term: str
+    highlight: str
     sentence: str
     date: str
     book_name: str


### PR DESCRIPTION
KOReader's vocabulary builder retains the original word from the sentence in a highlight column within its database if the word looked up in its dictionary has a different form. It should be used if present to ensure the meaning of a sentence isn't lost during import when studying languages with a lot of verb conjugations or noun declensions.

Before:
<img width="409" height="294" alt="image" src="https://github.com/user-attachments/assets/bbedee5e-a8e2-4446-9483-7f0852615419" />

After:
<img width="408" height="299" alt="image" src="https://github.com/user-attachments/assets/5b1c0ecf-e8e1-4ec2-a814-ee676b4e1389" />
