### PR TITLE
Use hbs to lemmatize Bosnian, Croatian, and Serbian

### DIFF
--- a/vocabsieve/lemmatizer.py
+++ b/vocabsieve/lemmatizer.py
@@ -89,6 +89,8 @@ def lemmatize(word, language, greedy=False):
             return morph[language].parse(word)[0].normal_form
         if language in simplemma_languages:
             return simplemma.lemmatize(word, lang=language, greedy=greedy)  # pyright: ignore[reportPrivateImportUsage]
+        if language in ['bs', 'hr', 'sr']:
+            return simplemma.lemmatize(word, lang='hbs', greedy=greedy)  # pyright: ignore[reportPrivateImportUsage]
         else:
             return word
     except ValueError as e:  # pylint: disable=redefined-outer-name


### PR DESCRIPTION
If the user's target language is set to Bosnian, Croatian, or Serbian, ensure the language code passed to `simplemma.lemmatize()` is set to `hbs`. This is because at present all three languages share a lemmatiser due to their similarity.